### PR TITLE
Changed google-cloud-storage version from 2.2.2 to 2.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>2.2.2</version>
+      <version>2.6.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
We've received this email stating that some of our GCS versions needed upgrading. As we use vfs-gcs we also need to update google-cloud-storage from 2.2.2.

This is what was sent to us: 
`We're writing to let you know that we have identified an issue with older versions of the Java Client Libraries and Object Lifecycle Management. Versions 1.50.0-2.2.3, 4.4.0 - 24.2.0 libraries-bom of this library will fail if buckets have configured any upcoming lifecycle actions. To read/set Google Cloud Storage buckets with any new lifecycle actions, update your Java client library to version 2.3.0 or higher.`